### PR TITLE
Fix RAM_D2 size of STM32H55/57 devices

### DIFF
--- a/Keil.STM32H7xx_DFP.pdsc
+++ b/Keil.STM32H7xx_DFP.pdsc
@@ -3348,7 +3348,7 @@ High-performance STM32H7 MCUs with Arm Cortex-M7 and Arm Cortex-M4 cores, MPU, L
 
         <!-- *************************  Device 'STM32H730IBTxQ'  ***************************** -->
         <device Dname="STM32H730IBTxQ">
-          <compile define="stm32h730xxq"/>
+          <compile define="STM32H730xxQ"/>
 
           <memory name="FLASH_Bank1" access="rx" start="0x08000000" size="0x00020000" default="1" startup="1"/>
 

--- a/Keil.STM32H7xx_DFP.pdsc
+++ b/Keil.STM32H7xx_DFP.pdsc
@@ -1546,7 +1546,7 @@ High-performance STM32H7 MCUs with Arm Cortex-M7 and Arm Cortex-M4 cores, MPU, L
         <memory Pname="CM7" name="RAM_D3"   access="rw"             start="0x38000000" size="0x00010000" default="1" init="0"/>
      <!--memory Pname="CM7" name="ITCMRAM"  access="rw"             start="0x00000000" size="0x00010000" default="1" init="0"/-->
 
-        <memory Pname="CM4" name="RAM_D2"   access="rw"             start="0x10000000" size="0x00030000" default="1" init="0"/>
+        <memory Pname="CM4" name="RAM_D2"   access="rw"             start="0x10000000" size="0x00040000" default="1" init="0"/>
         <memory Pname="CM4" name="RAM_D2S3" access="rw"             start="0x10040000" size="0x00008000" default="1" init="0"/>
 
         <!-- *************************  Device 'STM32H755BITx'  ***************************** -->
@@ -1883,7 +1883,7 @@ High-performance STM32H7 MCUs with Arm Cortex-M7 and Arm Cortex-M4 cores, MPU, L
         <memory Pname="CM7" name="RAM_D3"   access="rw"             start="0x38000000" size="0x00010000" default="1" init="0"/>
      <!--memory Pname="CM7" name="ITCMRAM"  access="rw"             start="0x00000000" size="0x00010000" default="1" init="0"/-->
 
-        <memory Pname="CM4" name="RAM_D2"   access="rw"             start="0x10000000" size="0x00030000" default="1" init="0"/>
+        <memory Pname="CM4" name="RAM_D2"   access="rw"             start="0x10000000" size="0x00040000" default="1" init="0"/>
         <memory Pname="CM4" name="RAM_D2S3" access="rw"             start="0x10040000" size="0x00008000" default="1" init="0"/>
 
         <!-- *************************  Device 'STM32H757AIIx'  ***************************** -->


### PR DESCRIPTION
The STM32H45/47 do not have this issue.

Also fixes a wrong CMSIS define for the STM32H730IBTxQ device.